### PR TITLE
Replace unwrapped function with a non modifying function when used as a first class callable

### DIFF
--- a/src/Mutators/Abstract/AbstractFunctionCallUnwrapMutator.php
+++ b/src/Mutators/Abstract/AbstractFunctionCallUnwrapMutator.php
@@ -5,8 +5,12 @@ declare(strict_types=1);
 namespace Pest\Mutate\Mutators\Abstract;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\ArrowFunction;
 use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Name;
+use PhpParser\Node\Param;
+use PhpParser\Node\VariadicPlaceholder;
 
 abstract class AbstractFunctionCallUnwrapMutator extends AbstractMutator
 {
@@ -30,8 +34,16 @@ abstract class AbstractFunctionCallUnwrapMutator extends AbstractMutator
 
     public static function mutate(Node $node): Node
     {
-        /** @var Node\Expr\FuncCall $node */
-        return $node->args[0]->value; // @phpstan-ignore-line
+        assert($node instanceof FuncCall);
+
+        if ($node->args[0] instanceof VariadicPlaceholder) {
+            return new ArrowFunction([
+                'params' => [new Param(new Variable('value'))],
+                'expr' => new Variable('value'),
+            ]);
+        }
+
+        return $node->args[0]->value;
     }
 
     abstract public static function functionName(): string;

--- a/tests/Mutators/String/UnwrapTrimTest.php
+++ b/tests/Mutators/String/UnwrapTrimTest.php
@@ -15,3 +15,15 @@ it('unwraps the trim function', function (): void {
         $a = 'foo ';
         CODE);
 });
+
+it('replaces a trim used as a first class callable with an empty callable', function (): void {
+    expect(mutateCode(UnwrapTrim::class, <<<'CODE'
+        <?php
+        
+        array_map(trim(...), $array);
+        CODE))->toBe(<<<'CODE'
+        <?php
+        
+        array_map(fn($value) => $value, $array);
+        CODE);
+});


### PR DESCRIPTION
This PR fixes https://github.com/pestphp/pest-plugin-mutate/issues/4

Does the following mutation:

```php
array_map(trim(...), $array);
```
to
```php
array_map(fn($value) => $value, $array);
```