### PR TITLE
fix: ignore null lines from code coverage

### DIFF
--- a/src/Tester/MutationTestRunner.php
+++ b/src/Tester/MutationTestRunner.php
@@ -108,7 +108,7 @@ class MutationTestRunner implements MutationTestRunnerContract
         /** @var CodeCoverage $codeCoverage */
         $codeCoverage = require $reportPath;
         unlink($reportPath);
-        $coveredLines = array_map(fn (array $lines): array => array_filter($lines, fn (array $tests): bool => $tests !== []), $codeCoverage->getData()->lineCoverage());
+        $coveredLines = array_map(fn (array $lines): array => array_filter($lines, fn (?array $tests): bool => $tests !== [] && $tests !== null), $codeCoverage->getData()->lineCoverage());
         $coveredLines = array_filter($coveredLines, fn (array $lines): bool => $lines !== []);
 
         $files = FileFinder::files($this->getConfiguration()->paths, $this->getConfiguration()->pathsToIgnore);


### PR DESCRIPTION
This seems to fix #6 for me.

I'm not so familiar with code coverage so I'm afraid I don't know how to create a test that reproduces this behavior.

Any feedback is appreciated.