### PR TITLE
Ensure `--processes` option is passed to the initial test run

### DIFF
--- a/src/Options/ProcessesOption.php
+++ b/src/Options/ProcessesOption.php
@@ -12,7 +12,7 @@ class ProcessesOption
 
     public static function remove(): bool
     {
-        return true;
+        return false;
     }
 
     public static function match(string $argument): bool


### PR DESCRIPTION
This PR fixes an issue, where the `--processes` option is removed and therefore ignored on the initial test run.

Fixes https://github.com/pestphp/pest/issues/1228

Replaces https://github.com/pestphp/pest-plugin-mutate/pull/13