### PR TITLE
Calculate mutation test timeout based on the initial test suite duration

### DIFF
--- a/src/MutationTest.php
+++ b/src/MutationTest.php
@@ -107,7 +107,7 @@ class MutationTest
             ->getInitialTestSuiteDuration()
             ->seconds();
 
-        return $initialTestSuiteDuration + max(5, $initialTestSuiteDuration * 1.2);
+        return $initialTestSuiteDuration + max(5, $initialTestSuiteDuration * 0.2);
     }
 
     public function hasFinished(): bool

--- a/src/MutationTest.php
+++ b/src/MutationTest.php
@@ -7,7 +7,7 @@ namespace Pest\Mutate;
 use ParaTest\Options;
 use Pest\Mutate\Event\Facade;
 use Pest\Mutate\Plugins\Mutate;
-use Pest\Mutate\Repositories\ConfigurationRepository;
+use Pest\Mutate\Repositories\TelemetryRepository;
 use Pest\Mutate\Support\Configuration\Configuration;
 use Pest\Mutate\Support\MutationTestResult;
 use Pest\Support\Container;
@@ -103,10 +103,11 @@ class MutationTest
 
     private function calculateTimeout(): int
     {
-        // TODO: calculate a reasonable timeout
-        return Container::getInstance()->get(ConfigurationRepository::class)->mergedConfiguration()->parallel ? // @phpstan-ignore-line
-            10 :
-            3;
+        $initialTestSuiteDuration = Container::getInstance()->get(TelemetryRepository::class) // @phpstan-ignore-line
+            ->getInitialTestSuiteDuration()
+            ->seconds();
+
+        return $initialTestSuiteDuration + max(5, $initialTestSuiteDuration * 1.2);
     }
 
     public function hasFinished(): bool

--- a/src/Repositories/TelemetryRepository.php
+++ b/src/Repositories/TelemetryRepository.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Mutate\Repositories;
+
+use PHPUnit\Event\Telemetry\Duration;
+
+class TelemetryRepository
+{
+    private Duration $initialTestSuiteDuration;
+
+    public function initialTestSuiteDuration(Duration $duration): void
+    {
+        $this->initialTestSuiteDuration = $duration;
+    }
+
+    public function getInitialTestSuiteDuration(): Duration
+    {
+        return $this->initialTestSuiteDuration;
+    }
+}

--- a/src/Subscribers/EnsureInitialTestRunWasSuccessful.php
+++ b/src/Subscribers/EnsureInitialTestRunWasSuccessful.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Pest\Mutate\Subscribers;
 
+use Pest\Mutate\Repositories\TelemetryRepository;
+use Pest\Support\Container;
 use PHPUnit\Event\Application\Finished;
 use PHPUnit\Event\Application\FinishedSubscriber;
 
@@ -12,5 +14,11 @@ use PHPUnit\Event\Application\FinishedSubscriber;
  */
 final class EnsureInitialTestRunWasSuccessful implements FinishedSubscriber
 {
-    public function notify(Finished $event): void {}
+    public function notify(Finished $event): void
+    {
+        // @phpstan-ignore-next-line
+        Container::getInstance()->get(TelemetryRepository::class)->initialTestSuiteDuration(
+            $event->telemetryInfo()->durationSinceStart()
+        );
+    }
 }


### PR DESCRIPTION
This PR implements the timeout duration calculation based on the initial test suite duration.

Fixes https://github.com/pestphp/pest/issues/1233