### PR TITLE
fix(uncovered-scenarios): tries to find related tests

### DIFF
--- a/src/MutationTest.php
+++ b/src/MutationTest.php
@@ -48,9 +48,16 @@ class MutationTest
     public function start(array $coveredLines, Configuration $configuration, array $originalArguments, ?int $processId = null): bool
     {
         // TODO: we should pass the tests to run in another way, maybe via cache, mutation or env variable
+
         $filters = [];
         foreach (range($this->mutation->startLine, $this->mutation->endLine) as $lineNumber) {
-            foreach ($coveredLines[$this->mutation->file->getRealPath()][$lineNumber] ?? [] as $test) {
+            $tests = $coveredLines[$this->mutation->file->getRealPath()][$lineNumber] ?? [];
+
+            if ($tests === [] && array_key_exists($this->mutation->file->getRealPath(), $coveredLines)) {
+                $tests = array_unique(array_merge(...array_values($coveredLines[$this->mutation->file->getRealPath()])));
+            }
+
+            foreach ($tests as $test) {
                 preg_match('/\\\\([a-zA-Z0-9]*)::(__pest_evaluable_)?([^#]*)"?/', $test, $matches);
                 if ($matches[2] === '__pest_evaluable_') { // @phpstan-ignore-line
                     $filters[] = $matches[1].'::(.*)'.str_replace(['__', '_'], ['.{1,2}', '.'], $matches[3]); // @phpstan-ignore-line
@@ -59,6 +66,7 @@ class MutationTest
                 }
             }
         }
+
         $filters = array_unique($filters);
 
         if ($filters === []) {


### PR DESCRIPTION
```php
class User extends Authenticatable
{
    protected $hidden = [
        'password',
        'remember_token',
    ];
```

Due to how coverage works, mutations on properties like these will **always** be marked as uncovered, as they do not appear in the code coverage report, even if methods like `->getHidden()` are tested.

This pull request aims to identify which tests might cover these properties by fetching all tests that include one or more covered lines in the same file.