### PR TITLE
Filter out coverage-related arguments from the original test process arguments

### DIFF
--- a/src/MutationTest.php
+++ b/src/MutationTest.php
@@ -81,10 +81,13 @@ class MutationTest
             $envs['LARAVEL_PARALLEL_TESTING'] = 1;
         }
 
+        // remove coverage arguments from the original arguments
+        $filteredArguments = array_filter($originalArguments, fn (string $argument): bool => ! str_starts_with($argument, '--coverage'));
+
         // TODO: filter arguments to remove unnecessary stuff (Teamcity, Coverage, etc.)
         $process = new Process(
             command: [
-                ...$originalArguments,
+                ...$filteredArguments,
                 '--bail',
                 '--filter="'.implode('|', $filters).'"',
             ],


### PR DESCRIPTION
In Pest v4 mutation testing is broken, if the default PHP binary has no coverage driver. The reason is the different behaviour of PHPUnit 12 when an option like `--coverage-php` available.

Therefore, we must ensure to remove all coverage related options when running Pest tests on for a given mutation.

In my case, I have a default Laravel Herd installation and execute mutation testing like this: `herd coverage vendor/bin/pest --mutate`