### PR TITLE
Fix (create mutations for uncovered classes): adjust regex to ignore classnames which are prefixed with a classname to create mutations for

### DIFF
--- a/src/Support/MutationGenerator.php
+++ b/src/Support/MutationGenerator.php
@@ -154,7 +154,7 @@ class MutationGenerator
             $namespace = preg_quote(implode('\\', $parts));
             $classOrNamespace = preg_quote($classOrNamespace);
 
-            if (preg_match("/namespace\\s+$namespace/", $contents) === 1 && preg_match("/(?:class|trait)\\s+$class.*/", $contents) === 1) {
+            if (preg_match("/namespace\\s+$namespace/", $contents) === 1 && preg_match("/(?:class|trait)\\s+$class\b.*/", $contents) === 1) {
                 return false;
             }
 

--- a/tests/Unit/MutationGeneratorTest.php
+++ b/tests/Unit/MutationGeneratorTest.php
@@ -96,7 +96,7 @@ it('generates mutations for the given file if it contains the given class', func
     [['AgeHelper'], 2],
     [['SizeHelper'], 0],
     [[AgeHelper::class], 2],
-    [['Tests\\Fixtures\\Classes\\AgeHelp'], 2],
+    [['Tests\\Fixtures\\Classes\\AgeHelp'], 0],
     [['Invalid\\Namespace\\AgeHelper'], 0],
     [['Invalid\\Namespace\\AgeHelp'], 0],
     [['Invalid\\Namespace\\AgeHelper', AgeHelper::class], 2],
@@ -118,7 +118,7 @@ it('generates mutations for the given file if it contains the given trait', func
     [[SizeHelper::class], 0],
     [[SizeHelperTrait::class, SizeHelper::class], 1],
     [['SizeHelperTrait'], 1],
-    [['Tests\\Fixtures\\Traits\\SizeHelperTrai'], 1],
+    [['Tests\\Fixtures\\Traits\\SizeHelperTrai'], 0],
     [['Invalid\\Namespace\\SizeHelperTrait'], 0],
 ]);
 


### PR DESCRIPTION
Given following classes:

```PHP
final class User implements UserInterface
{
    ...
}
```

```PHP
final class UserCollection implements CollectionInterface
{
    ...
}
```

and a testfile:

```PHP
covers(User::Class);
...
```

Currently the plugin  would create mutations for both classes, even though the `UserCollection` class does not have any tests. This is due to the Regex in `\Pest\Mutate\Support\MutationGenerator::doesNotContainClassToMutate` `/(?:class|trait)\\s+$class.*/`. The $class.* will match everything that starts with the name of the target class.

This PR adds a word boundary after `$class` to prevent that.
