### PR TITLE
Fix: FileFinder silently drops glob paths from phpunit source directories

### DIFF
--- a/src/Support/FileFinder.php
+++ b/src/Support/FileFinder.php
@@ -39,6 +39,16 @@ class FileFinder
             if (! str_starts_with($path, DIRECTORY_SEPARATOR)) {
                 $path = getcwd().DIRECTORY_SEPARATOR.$path;
             }
+
+            if (str_contains($path, '*')) {
+                $expanded = glob($path, GLOB_ONLYDIR);
+                if ($expanded !== false) {
+                    $dirs = [...$dirs, ...$expanded];
+                }
+    
+                continue;
+            }
+    
             if (is_dir($path)) {
                 $dirs[] = $path;
             } elseif (is_file($path)) {
@@ -46,7 +56,7 @@ class FileFinder
                 $files[] = new SplFileInfo($file->getPathname(), $file->getPath(), $file->getFilename());
             }
         }
-
+    
         return ['directories' => $dirs, 'files' => $files];
     }
 


### PR DESCRIPTION
When `phpunit.xml` uses glob patterns in `<source><include><directory>` (e.g. `Modules/*/app`), PHPUnit resolves the glob at runtime, but `pest-plugin-mutate` receives the **literal unresolved string** from PHPUnit's configuration object. Since `is_dir("Modules/*/app")` returns `false`.

Affecting any project where `phpunit.xml` uses wildcard patterns.

Fixes https://github.com/pestphp/pest/issues/1313