### PR TITLE
Fix: recognize Windows drive-letter absolute paths in FileFinder

### DIFF
--- a/src/Support/FileFinder.php
+++ b/src/Support/FileFinder.php
@@ -36,7 +36,7 @@ class FileFinder
         $dirs = [];
         $files = [];
         foreach ($paths as $path) {
-            if (! str_starts_with($path, DIRECTORY_SEPARATOR)) {
+            if (! self::isAbsolutePath($path)) {
                 $path = getcwd().DIRECTORY_SEPARATOR.$path;
             }
             if (is_dir($path)) {
@@ -48,6 +48,31 @@ class FileFinder
         }
 
         return ['directories' => $dirs, 'files' => $files];
+    }
+
+    /**
+     * Determine whether a path is absolute, in a cross-platform way.
+     *
+     * The previous check — str_starts_with($path, DIRECTORY_SEPARATOR) — only
+     * recognised a leading separator. On Windows that misread a drive-letter
+     * absolute path (e.g. "C:\project\app", which PHPUnit hands us for every
+     * <source> include directory) as *relative*: getcwd() was then prepended,
+     * producing a non-existent doubled path that is_dir() rejected, so the
+     * directory was silently dropped and no mutations were generated. This
+     * mirrors PHPUnit's own drive-letter-aware absoluteness check.
+     */
+    private static function isAbsolutePath(string $path): bool
+    {
+        // A leading separator: POSIX "/…", or "\…" / UNC "\\server\share" on Windows.
+        if (str_starts_with($path, '/') || str_starts_with($path, '\\')) {
+            return true;
+        }
+
+        // A Windows drive-letter prefix: "C:\…" or "C:/…".
+        return strlen($path) >= 3
+            && ctype_alpha($path[0])
+            && $path[1] === ':'
+            && ($path[2] === '/' || $path[2] === '\\');
     }
 
     /**

--- a/tests/Unit/Support/FileFinderTest.php
+++ b/tests/Unit/Support/FileFinderTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+use Pest\Mutate\Support\FileFinder;
+use Symfony\Component\Finder\SplFileInfo;
+
+/**
+ * Invoke the private cross-platform absolute-path classifier.
+ *
+ * Reflection keeps the helper private (no public API change) while letting the
+ * Linux CI runner verify the Windows drive-letter cases it cannot exercise
+ * through real directories. Matches the reflection usage already in tests/Arch.php.
+ */
+function isAbsolutePath(string $path): bool
+{
+    return (bool) (new ReflectionMethod(FileFinder::class, 'isAbsolutePath'))->invoke(null, $path);
+}
+
+describe('isAbsolutePath()', function (): void {
+    it('treats leading-separator paths as absolute', function (string $path): void {
+        expect(isAbsolutePath($path))->toBeTrue();
+    })->with([
+        'POSIX root' => '/var/www/app',
+        'POSIX short' => '/app',
+        'UNC share' => '\\\\server\\share',
+        'leading backslash' => '\\app',
+    ]);
+
+    it('treats Windows drive-letter paths as absolute', function (string $path): void {
+        expect(isAbsolutePath($path))->toBeTrue();
+    })->with([
+        'drive + backslash' => 'C:\\project\\app', // the path PHPUnit hands the plugin on Windows
+        'drive + forward slash' => 'C:/project/app',
+        'lower-case drive' => 'd:\\app',
+    ]);
+
+    it('treats relative paths as not absolute', function (string $path): void {
+        expect(isAbsolutePath($path))->toBeFalse();
+    })->with([
+        'bare directory' => 'app',
+        'nested' => 'tests/Unit',
+        'src' => 'src',
+        'drive-relative (no separator)' => 'C:app',
+        'empty' => '',
+    ]);
+});
+
+it('finds php files when given an absolute source directory', function (): void {
+    // Regression for the Windows bug: PHPUnit supplies an ABSOLUTE <source>
+    // directory; FileFinder must not prepend getcwd() to it (which doubled the
+    // path and dropped the directory, yielding "0 Mutations for 0 Files created").
+    $absolute = dirname(__DIR__, 2).DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'Classes';
+
+    expect($absolute)->toBeDirectory();
+
+    $names = array_map(
+        fn (SplFileInfo $file): string => $file->getFilename(),
+        iterator_to_array(FileFinder::files([$absolute], [])),
+    );
+
+    expect($names)->toContain('AgeHelper.php', 'SizeHelper.php');
+});


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

On Windows, running `pest --mutate` without an explicit `--path` finds nothing to mutate — it prints `0 Mutations for 0 Files created`, even with a coverage driver installed.

When you don't pass `--path`, the plugin takes its directories from PHPUnit's `<source>` configuration, and PHPUnit gives those as **absolute** paths. `FileFinder::separateDirectoriesAndFiles()` then decides whether each path is relative like this:

```php
if (! str_starts_with($path, DIRECTORY_SEPARATOR)) {
    $path = getcwd().DIRECTORY_SEPARATOR.$path;
}
```

On Windows, `DIRECTORY_SEPARATOR` is `\`, but an absolute Windows path begins with a drive letter such as `C:\project\app` — not `\`. So this treats the path as relative and adds `getcwd()` in front of it, producing a path that doesn't exist: `C:\project\C:\project\app`. `is_dir()` is then false, the directory is skipped, and the finder has nothing to scan.

This only happens on Windows. On Linux and macOS an absolute path starts with `/`, which is `DIRECTORY_SEPARATOR`, so the check works and CI never sees it. Passing a relative `--path=app` also avoids it, which is the usual workaround.

**The fix.** Add a small `isAbsolutePath()` check that also treats a drive-letter path (`C:\...` or `C:/...`) and a UNC path (`\\server\share`) as absolute — the same way PHPUnit decides this itself. Relative paths still get `getcwd()` added in front, so `--path=app` and similar keep working, and nothing changes on Linux or macOS.

**Tests.** A new `tests/Unit/Support/FileFinderTest.php`:

- checks the new method directly for absolute paths (Unix `/...`, UNC, and Windows drive letters in upper and lower case) and for relative paths (including `C:foo`, which is relative, and an empty string), so the Windows cases are covered even when the suite runs on Linux;
- runs `FileFinder::files()` against a real absolute source directory and confirms it finds the fixture files. This fails on the current `4.x` on Windows (it finds nothing) and passes with the fix.

**Notes.**

- Nothing changes on Linux or macOS: absolute paths still start with `/`, and relative paths are still resolved against `getcwd()`.
- The same `str_starts_with($x, DIRECTORY_SEPARATOR)` check is also used in `FileFinder::buildPathsToIgnore()` (lines 63 and 69 on `4.x`), so a Windows drive-letter path in the ignore list has the same problem and may not be excluded. That is less serious than the source-path case — a missed exclusion rather than zero mutations — has no reproduction yet, and fixing it properly also means reworking the nearby `getcwd()` handling, so I left it out to keep this PR focused. Flagging it here; happy to follow up.
- This edits the same line as #23, which fixes a separate glob-pattern case just below it. The two changes are independent and apply cleanly together.
- `composer test:lint`, `test:types`, `test:refacto`, `test:type-coverage`, and `test:unit` all pass.

