### PR TITLE
Fix: read the php-code-coverage 14 `--coverage-php` array format

### DIFF
--- a/src/Tester/MutationTestRunner.php
+++ b/src/Tester/MutationTestRunner.php
@@ -20,6 +20,7 @@ use Pest\Support\Container;
 use Pest\Support\Coverage;
 use Psr\SimpleCache\CacheInterface;
 use SebastianBergmann\CodeCoverage\CodeCoverage;
+use SebastianBergmann\CodeCoverage\Data\ProcessedCodeCoverageData;
 
 class MutationTestRunner implements MutationTestRunnerContract
 {
@@ -109,11 +110,27 @@ class MutationTestRunner implements MutationTestRunnerContract
 
         Facade::instance()->emitter()->startMutationGeneration($mutationSuite);
 
-        /** @var CodeCoverage $codeCoverage */
-        $codeCoverage = require $reportPath;
+        /** @var CodeCoverage|array{basePath: string, codeCoverage: ProcessedCodeCoverageData} $loadedCoverage */
+        $loadedCoverage = require $reportPath;
 
         unlink($reportPath);
-        $coveredLines = array_map(fn (array $lines): array => array_filter($lines, fn (?array $tests): bool => $tests !== [] && $tests !== null), $codeCoverage->getData()->lineCoverage());
+
+        if ($loadedCoverage instanceof CodeCoverage) {
+            $coverageData = $loadedCoverage->getData();
+        } else {
+            // since phpunit/php-code-coverage 14, `--coverage-php` writes an array instead of a
+            // serialized CodeCoverage, and its file keys are relative to `basePath`
+            $coverageData = $loadedCoverage['codeCoverage'];
+            $basePath = $loadedCoverage['basePath'];
+
+            if ($basePath !== '') {
+                foreach ($coverageData->coveredFiles() as $relativePath) {
+                    $coverageData->renameFile($relativePath, $basePath.DIRECTORY_SEPARATOR.$relativePath);
+                }
+            }
+        }
+
+        $coveredLines = array_map(fn (array $lines): array => array_filter($lines, fn (?array $tests): bool => $tests !== [] && $tests !== null), $coverageData->lineCoverage());
         $coveredLines = array_filter($coveredLines, fn (array $lines): bool => $lines !== []);
 
         $files = FileFinder::files($this->getConfiguration()->paths, $this->getConfiguration()->pathsToIgnore);


### PR DESCRIPTION
`MutationTestRunner::run()` reads the `--coverage-php` report with `require` and calls `->getData()` on it. Since `phpunit/php-code-coverage` 14 that file returns an array, so every `--mutate` run on Pest 5 aborts with `Call to a member function getData() on array`.

Its `codeCoverage` entry is keyed relative to `basePath`, so those keys need rebasing too, or `--covered-only` reports `0 Mutations for 0 Files created` and exits 0. Same handling core already has in `Pest\Plugins\Tia\CoverageMerger`; the object form keeps the old path.

Fixes https://github.com/pestphp/pest/issues/1790
