### PR TITLE
fix: support the php-code-coverage 14.3 line coverage shape

### DIFF
--- a/src/Tester/MutationTestRunner.php
+++ b/src/Tester/MutationTestRunner.php
@@ -130,8 +130,7 @@ class MutationTestRunner implements MutationTestRunnerContract
             }
         }
 
-        $coveredLines = array_map(fn (array $lines): array => array_filter($lines, fn (?array $tests): bool => $tests !== [] && $tests !== null), $coverageData->lineCoverage());
-        $coveredLines = array_filter($coveredLines, fn (array $lines): bool => $lines !== []);
+        $coveredLines = $this->coveredLines($coverageData);
 
         $files = FileFinder::files($this->getConfiguration()->paths, $this->getConfiguration()->pathsToIgnore);
 
@@ -190,6 +189,62 @@ class MutationTestRunner implements MutationTestRunnerContract
         Facade::instance()->emitter()->finishMutationSuite($mutationSuite);
 
         return $this->isMinScoreIsReached($mutationSuite) ? 0 : 1;
+    }
+
+    /**
+     * Returns the tests covering each line, as `[file => [line => [testId, ...]]]`.
+     *
+     * @return array<string, array<int, array<int, string>>>
+     */
+    private function coveredLines(ProcessedCodeCoverageData $coverageData): array
+    {
+        /** @var array<int, string> $testIds */
+        $testIds = method_exists($coverageData, 'testIds') ? $coverageData->testIds() : []; // @phpstan-ignore function.alreadyNarrowedType
+
+        $coveredLines = [];
+
+        foreach ($coverageData->lineCoverage() as $file => $lines) {
+            foreach ($lines as $line => $tests) {
+                $ids = $this->testIdsCoveringLine($tests ?? [], $testIds);
+
+                if ($ids === []) {
+                    continue;
+                }
+
+                $coveredLines[$file][$line] = $ids;
+            }
+        }
+
+        return $coveredLines;
+    }
+
+    /**
+     * Resolves the test ids a single line holds.
+     *
+     * Up to phpunit/php-code-coverage 14.2 a line held the test ids themselves. Since
+     * 14.3 it holds hit counts, keyed by an index into the coverage data's test ids.
+     *
+     * @param  array<int|string, mixed>  $tests
+     * @param  array<int, string>  $testIds
+     * @return array<int, string>
+     */
+    private function testIdsCoveringLine(array $tests, array $testIds): array
+    {
+        $ids = [];
+
+        foreach ($tests as $index => $test) {
+            if (is_string($test)) {
+                $ids[] = $test;
+
+                continue;
+            }
+
+            if (is_int($index) && isset($testIds[$index])) {
+                $ids[] = $testIds[$index];
+            }
+        }
+
+        return $ids;
     }
 
     private function getConfiguration(): Configuration

--- a/tests/Unit/Tester/MutationTestRunnerTest.php
+++ b/tests/Unit/Tester/MutationTestRunnerTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Pest\Mutate\Tester\MutationTestRunner;
+
+/**
+ * @param  array<int|string, mixed>  $tests
+ * @param  array<int, string>  $testIds
+ * @param  array<int, string>  $expected
+ */
+it('resolves the tests covering a line from either code coverage shape', function (array $tests, array $testIds, array $expected): void {
+    $runner = new MutationTestRunner;
+
+    $method = new ReflectionClass($runner)->getMethod('testIdsCoveringLine');
+
+    expect($method->invoke($runner, $tests, $testIds))->toBe($expected);
+})->with([
+    'ids in the values, up to php-code-coverage 14.2' => [
+        ['P\Tests\Unit\FooTest::__pest_evaluable_it_works', 'Tests\Unit\BarTest::test_baz'],
+        [],
+        ['P\Tests\Unit\FooTest::__pest_evaluable_it_works', 'Tests\Unit\BarTest::test_baz'],
+    ],
+    'hit counts keyed by index, since php-code-coverage 14.3' => [
+        [0 => 1, 2 => 4],
+        [
+            0 => 'P\Tests\Unit\FooTest::__pest_evaluable_it_works',
+            1 => 'Tests\Unit\OtherTest::test_untouched',
+            2 => 'Tests\Unit\BarTest::test_baz',
+        ],
+        ['P\Tests\Unit\FooTest::__pest_evaluable_it_works', 'Tests\Unit\BarTest::test_baz'],
+    ],
+    'an index with no test id is dropped' => [[7 => 1], [0 => 'Tests\Unit\FooTest::test_baz'], []],
+    'nothing covers the line' => [[], [], []],
+]);


### PR DESCRIPTION
php-code-coverage 14.3 changed the shape of `ProcessedCodeCoverageData::lineCoverage()`. A line used to hold the list of test ids covering it; it now holds hit counts keyed by an index into a separate list returned by `testIds()`.

Mutation testing reads that structure to work out which tests cover a mutation. Against 14.3 it receives integers where strings are expected, and every run aborts on the first covered mutation with `preg_match(): Argument #2 ($subject) must be of type string, int given`.

`phpunit/phpunit` allows `phpunit/php-code-coverage: ^14.2.3`, so both shapes are in circulation and both have to keep working.

## What changed

`MutationTestRunner::coveredLines()` normalises the coverage data into `[file => [line => [testId, ...]]]` before anything consumes it. `testIdsCoveringLine()` tells the two shapes apart by their structure rather than by a version check: a string value is a test id from 14.2 and earlier, an integer key is an index into the ids reported by 14.3.

This also clears the two pre-existing PHPStan errors on `MutationTestRunner`, which were the same mismatch surfacing statically.

## Testing

`tests/Unit/Tester/MutationTestRunnerTest.php` covers both shapes, an index with no matching test id, and a line nothing covers.

## Follow-ups

Mutation sharding builds on this fix in #40 and #41, and on pestphp/pest#1829.
