### PR TITLE
fix: keep the mutation timeout window independent of sharding

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,12 +30,12 @@
         "psr/simple-cache": "^3.0.0"
     },
     "require-dev": {
-        "pestphp/pest": "^5.0.3",
+        "pestphp/pest": "^5.1.0",
         "pestphp/pest-dev-tools": "^5.0.0",
         "pestphp/pest-plugin-type-coverage": "^5.0.0"
     },
     "conflict": {
-        "pestphp/pest": "<5.0.0"
+        "pestphp/pest": "<5.1.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/MutationTest.php
+++ b/src/MutationTest.php
@@ -22,6 +22,13 @@ class MutationTest
 
     private ?float $finish = null;
 
+    /**
+     * The test classes covering this mutation.
+     *
+     * @var array<int, string>
+     */
+    private array $coveringTestClasses = [];
+
     private Process $process;
 
     public function __construct(public readonly Mutation $mutation) {}
@@ -49,11 +56,14 @@ class MutationTest
     {
         // TODO: we should pass the tests to run in another way, maybe via cache, mutation or env variable
         $filters = [];
+        $coveringTestClasses = [];
         foreach (range($this->mutation->startLine, $this->mutation->endLine) as $lineNumber) {
             foreach ($coveredLines[$this->mutation->file->getRealPath()][$lineNumber] ?? [] as $test) {
                 if (preg_match('/\\\\([a-zA-Z0-9]*)::(__pest_evaluable_)?([^#]*)"?/', $test, $matches) !== 1) {
                     continue;
                 }
+
+                $coveringTestClasses[] = $this->testClass($test);
 
                 if ($matches[2] === '__pest_evaluable_') {
                     $filters[] = $matches[1].'::(.*)'.str_replace(['__', '_'], ['.{1,2}', '.'], $matches[3]);
@@ -63,6 +73,8 @@ class MutationTest
             }
         }
         $filters = array_unique($filters);
+
+        $this->coveringTestClasses = array_values(array_unique($coveringTestClasses));
 
         if ($filters === []) {
             $this->updateResult(MutationTestResult::Uncovered);
@@ -105,6 +117,32 @@ class MutationTest
         $this->process = $process;
 
         return true;
+    }
+
+    /**
+     * Returns the test classes covering this mutation.
+     *
+     * @return array<int, string>
+     */
+    public function coveringTestClasses(): array
+    {
+        return $this->coveringTestClasses;
+    }
+
+    /**
+     * Extracts the fully qualified class name from a code coverage test identifier.
+     *
+     * The filter above keeps only the last segment of the name, which is all a
+     * `--filter` pattern needs. Sharding matches against the fully qualified names
+     * `--list-tests` reports, so it needs the whole thing, minus Pest's `P\` prefix.
+     */
+    private function testClass(string $test): string
+    {
+        $separator = strpos($test, '::');
+
+        $class = $separator === false ? $test : substr($test, 0, $separator);
+
+        return preg_replace('/^P\\\\/', '', $class) ?? $class;
     }
 
     private function calculateTimeout(): int

--- a/src/Options/LogJsonOption.php
+++ b/src/Options/LogJsonOption.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Mutate\Options;
+
+use Symfony\Component\Console\Input\InputOption;
+
+class LogJsonOption
+{
+    final public const string ARGUMENT = 'log-json';
+
+    public static function remove(): bool
+    {
+        return true;
+    }
+
+    public static function match(string $argument): bool
+    {
+        return str_starts_with($argument, sprintf('--%s=', self::ARGUMENT));
+    }
+
+    public static function inputOption(): InputOption
+    {
+        return new InputOption(sprintf('--%s', self::ARGUMENT), null, InputOption::VALUE_REQUIRED, '');
+    }
+}

--- a/src/Plugins/Mutate.php
+++ b/src/Plugins/Mutate.php
@@ -40,6 +40,7 @@ use Pest\Mutate\Support\Printers\DefaultPrinter;
 use Pest\Mutate\Support\StreamWrapper;
 use Pest\Plugins\Concerns\HandleArguments;
 use Pest\Plugins\Parallel;
+use Pest\Plugins\Shard;
 use Pest\Support\Container;
 use Pest\Support\Coverage;
 use Psr\SimpleCache\CacheInterface;
@@ -124,6 +125,10 @@ class Mutate implements AddsOutput, Bootable, HandlesArguments
 
         $mutationTestRunner->enable();
         $this->ensurePrinterIsRegistered();
+
+        // Mutation time does not correlate with test time, so sharded mutation runs get
+        // their own timings file rather than sharing the one regular runs write.
+        Shard::useTimingsFile('mutation-shards.json');
 
         $coverageRequired = array_filter($arguments, fn (string $argument): bool => str_starts_with($argument, '--coverage')) !== [];
         if ($coverageRequired) {

--- a/src/Repositories/ConfigurationRepository.php
+++ b/src/Repositories/ConfigurationRepository.php
@@ -109,6 +109,7 @@ class ConfigurationRepository
             mutationId: $config['mutation_id'] ?? null,
             retry: $config['retry'] ?? false,
             everything: $config['everything'] ?? false,
+            logJson: $config['log_json'] ?? null,
         );
     }
 

--- a/src/Repositories/MutationRepository.php
+++ b/src/Repositories/MutationRepository.php
@@ -94,6 +94,56 @@ class MutationRepository
         return array_slice($allTests, 0, 10);
     }
 
+    /**
+     * Returns the shard units, one per mutated file.
+     *
+     * A file is the unit of mutation work: every mutation belongs to exactly one, and
+     * the tests covering it must run in the same shard for the result to be honest.
+     * Sharding test classes instead would regenerate a file's mutations in every shard
+     * holding one of its covering tests, and report the ones killed elsewhere as escaped.
+     *
+     * @return array<string, array{time: float, tests: list<string>}>
+     */
+    public function units(string $rootPath): array
+    {
+        $units = [];
+
+        foreach ($this->tests as $file => $testCollection) {
+            $time = 0.0;
+            $tests = [];
+
+            foreach ($testCollection->tests() as $test) {
+                $time += $test->duration();
+
+                foreach ($test->coveringTestClasses() as $class) {
+                    $tests[$class] = true;
+                }
+            }
+
+            if ($tests === []) {
+                continue;
+            }
+
+            $units[$this->relativePath($file, $rootPath)] = [
+                'time' => round($time, 4),
+                'tests' => array_keys($tests),
+            ];
+        }
+
+        return $units;
+    }
+
+    /**
+     * Makes a mutated file's path relative to the root, so the units survive being
+     * written on one machine and read on another.
+     */
+    private function relativePath(string $file, string $rootPath): string
+    {
+        $prefix = rtrim($rootPath, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
+
+        return str_starts_with($file, $prefix) ? substr($file, strlen($prefix)) : $file;
+    }
+
     public function sortByEscapedFirst(): void
     {
         uasort($this->tests, fn (MutationTestCollection $a, MutationTestCollection $b): int => $b->hasLastRunEscapedMutation() <=> $a->hasLastRunEscapedMutation());

--- a/src/Support/Configuration/AbstractConfiguration.php
+++ b/src/Support/Configuration/AbstractConfiguration.php
@@ -58,6 +58,8 @@ abstract class AbstractConfiguration implements ConfigurationContract
 
     private ?bool $everything = null;
 
+    private ?string $logJson = null;
+
     /**
      * {@inheritDoc}
      */
@@ -144,6 +146,17 @@ abstract class AbstractConfiguration implements ConfigurationContract
         return $this;
     }
 
+    /**
+     * Writes the results of this run to the given file, so that sharded runs can be
+     * added up into one report afterwards.
+     */
+    public function logJson(string $path): self
+    {
+        $this->logJson = $path;
+
+        return $this;
+    }
+
     public function stopOnUntested(bool $stopOnUntested = true): self
     {
         $this->stopOnUntested = $stopOnUntested;
@@ -194,7 +207,7 @@ abstract class AbstractConfiguration implements ConfigurationContract
     }
 
     /**
-     * @return array{covered_only?: bool, paths?: string[], paths_to_ignore?: string[], mutators?: class-string<Mutator>[], excluded_mutators?: class-string<Mutator>[], classes?: string[], parallel?: bool, processes?: int, profile?: bool, min_score?: float, ignore_min_score_on_zero_mutations?: bool, covered_only?: bool, stop_on_untested?: bool, stop_on_uncovered?: bool, mutation_id?: string, retry?: bool, everything?: bool}
+     * @return array{covered_only?: bool, paths?: string[], paths_to_ignore?: string[], mutators?: class-string<Mutator>[], excluded_mutators?: class-string<Mutator>[], classes?: string[], parallel?: bool, processes?: int, profile?: bool, min_score?: float, ignore_min_score_on_zero_mutations?: bool, covered_only?: bool, stop_on_untested?: bool, stop_on_uncovered?: bool, mutation_id?: string, retry?: bool, everything?: bool, log_json?: string}
      */
     public function toArray(): array
     {
@@ -215,6 +228,7 @@ abstract class AbstractConfiguration implements ConfigurationContract
             'mutation_id' => $this->mutationId,
             'retry' => $this->retry,
             'everything' => $this->everything,
+            'log_json' => $this->logJson,
         ], fn (mixed $value): bool => ! is_null($value));
     }
 

--- a/src/Support/Configuration/CliConfiguration.php
+++ b/src/Support/Configuration/CliConfiguration.php
@@ -13,6 +13,7 @@ use Pest\Mutate\Options\EverythingOption;
 use Pest\Mutate\Options\ExceptOption;
 use Pest\Mutate\Options\IgnoreMinScoreOnZeroMutationsOption;
 use Pest\Mutate\Options\IgnoreOption;
+use Pest\Mutate\Options\LogJsonOption;
 use Pest\Mutate\Options\MinScoreOption;
 use Pest\Mutate\Options\MutateOption;
 use Pest\Mutate\Options\MutationIdOption;
@@ -44,6 +45,7 @@ class CliConfiguration extends AbstractConfiguration
         ParallelOption::class,
         ProcessesOption::class,
         ProfileOption::class,
+        LogJsonOption::class,
         StopOnUntestedOption::class,
         StopOnUncoveredOption::class,
         BailOption::class,
@@ -116,6 +118,10 @@ class CliConfiguration extends AbstractConfiguration
 
         if ($input->hasOption(ProfileOption::ARGUMENT)) {
             $this->profile($input->getOption(ProfileOption::ARGUMENT) !== 'false');
+        }
+
+        if ($input->hasOption(LogJsonOption::ARGUMENT)) {
+            $this->logJson((string) $input->getOption(LogJsonOption::ARGUMENT)); // @phpstan-ignore-line
         }
 
         if ($_SERVER['COLLISION_PRINTER_PROFILE'] ?? false) {

--- a/src/Support/Configuration/Configuration.php
+++ b/src/Support/Configuration/Configuration.php
@@ -30,5 +30,6 @@ class Configuration
         public readonly ?string $mutationId,
         public readonly bool $retry,
         public readonly bool $everything,
+        public readonly ?string $logJson,
     ) {}
 }

--- a/src/Tester/MutationTestRunner.php
+++ b/src/Tester/MutationTestRunner.php
@@ -16,8 +16,10 @@ use Pest\Mutate\Repositories\TelemetryRepository;
 use Pest\Mutate\Support\Configuration\Configuration;
 use Pest\Mutate\Support\FileFinder;
 use Pest\Mutate\Support\MutationGenerator;
+use Pest\Plugins\Shard;
 use Pest\Support\Container;
 use Pest\Support\Coverage;
+use Pest\TestSuite;
 use Psr\SimpleCache\CacheInterface;
 use SebastianBergmann\CodeCoverage\CodeCoverage;
 use SebastianBergmann\CodeCoverage\Data\ProcessedCodeCoverageData;
@@ -137,7 +139,13 @@ class MutationTestRunner implements MutationTestRunnerContract
         /** @var MutationGenerator $generator */
         $generator = Container::getInstance()->get(MutationGenerator::class);
 
+        $shardFiles = $this->shardFiles();
+
         foreach ($files as $file) {
+            if ($shardFiles !== null && ! isset($shardFiles[$file->getRealPath()])) {
+                continue;
+            }
+
             $linesToMutate = [];
 
             if ($this->getConfiguration()->coveredOnly) {
@@ -185,6 +193,14 @@ class MutationTestRunner implements MutationTestRunnerContract
         }
 
         $mutationSuite->repository->saveResults();
+
+        $this->writeJsonLog($mutationSuite);
+
+        // A suite cut short by --bail or --stop-on-* holds partial durations, which would
+        // make for a badly balanced shards file.
+        if (! $this->stop) {
+            Shard::useTimings($mutationSuite->repository->units(TestSuite::getInstance()->rootPath));
+        }
 
         Facade::instance()->emitter()->finishMutationSuite($mutationSuite);
 
@@ -245,6 +261,72 @@ class MutationTestRunner implements MutationTestRunnerContract
         }
 
         return $ids;
+    }
+
+    /**
+     * Writes this run's results, so that sharded runs can be added up afterwards.
+     *
+     * Shards own disjoint sets of mutations, so summing the counters of every shard
+     * reproduces the score of a single unsharded run exactly.
+     */
+    private function writeJsonLog(MutationSuite $mutationSuite): void
+    {
+        $path = $this->getConfiguration()->logJson;
+
+        if ($path === null) {
+            return;
+        }
+
+        $repository = $mutationSuite->repository;
+
+        $directory = dirname($path);
+
+        if (! is_dir($directory)) {
+            mkdir($directory, 0755, true);
+        }
+
+        file_put_contents($path, json_encode([
+            'tested' => $repository->tested(),
+            'untested' => $repository->untested(),
+            'timeout' => $repository->timedOut(),
+            'uncovered' => $repository->uncovered(),
+            'not_run' => $repository->notRun(),
+            'total' => $repository->total(),
+            'score' => round($repository->score(), 2),
+        ], JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR)."\n");
+    }
+
+    /**
+     * Returns the absolute paths of the mutated files this shard owns, or null when the
+     * run is not sharded.
+     *
+     * The restriction is applied here rather than through `--path` or `--class`, because
+     * passing either of those lifts the `__pest_mutate_only` group and makes every shard
+     * run the whole test suite instead of only the tests declaring `covers()`.
+     *
+     * @return array<string, true>|null
+     */
+    private function shardFiles(): ?array
+    {
+        $units = Shard::selectedUnits();
+
+        if ($units === []) {
+            return null;
+        }
+
+        $root = rtrim(TestSuite::getInstance()->rootPath, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
+
+        $files = [];
+
+        foreach ($units as $unit) {
+            $path = realpath(str_starts_with($unit, DIRECTORY_SEPARATOR) ? $unit : $root.$unit);
+
+            if ($path !== false) {
+                $files[$path] = true;
+            }
+        }
+
+        return $files;
     }
 
     private function getConfiguration(): Configuration

--- a/src/Tester/MutationTestRunner.php
+++ b/src/Tester/MutationTestRunner.php
@@ -96,9 +96,10 @@ class MutationTestRunner implements MutationTestRunnerContract
 
     public function run(): int
     {
-        Container::getInstance()->get(TelemetryRepository::class)->initialTestSuiteDuration( // @phpstan-ignore-line
-            microtime(true) - $this->startTime
-        );
+        /** @var TelemetryRepository $telemetryRepository */
+        $telemetryRepository = Container::getInstance()->get(TelemetryRepository::class);
+
+        $telemetryRepository->initialTestSuiteDuration($this->initialTestSuiteDuration());
 
         if (! Coverage::isAvailable() || ! file_exists($reportPath = Coverage::getPath())) {
             Container::getInstance()->get(Printer::class)->reportError('No coverage report found, aborting mutation testing.'); // @phpstan-ignore-line
@@ -199,7 +200,10 @@ class MutationTestRunner implements MutationTestRunnerContract
         // A suite cut short by --bail or --stop-on-* holds partial durations, which would
         // make for a badly balanced shards file.
         if (! $this->stop) {
-            Shard::useTimings($mutationSuite->repository->units(TestSuite::getInstance()->rootPath));
+            Shard::useTimings(
+                $mutationSuite->repository->units(TestSuite::getInstance()->rootPath),
+                ['suite_time' => round($telemetryRepository->getInitialTestSuiteDuration(), 4)],
+            );
         }
 
         Facade::instance()->emitter()->finishMutationSuite($mutationSuite);
@@ -261,6 +265,32 @@ class MutationTestRunner implements MutationTestRunnerContract
         }
 
         return $ids;
+    }
+
+    /**
+     * Returns the duration a mutation's test run is measured against.
+     *
+     * Each mutation is given a timeout derived from this, so it has to describe the same
+     * amount of work whether or not the suite is sharded. A shard only runs part of the
+     * suite, so its own initial run is shorter, and mutations that are killed honestly on
+     * a full run would be cut off as timeouts instead. The reference duration recorded by
+     * the unsharded `--update-shards` run is therefore preferred whenever it is longer.
+     *
+     * Only ever called once, at the start of the mutation suite: it measures from the
+     * start of the process, so calling it again later would fold the mutation suite's own
+     * duration into the reference.
+     */
+    private function initialTestSuiteDuration(): float
+    {
+        $measured = microtime(true) - $this->startTime;
+
+        $reference = Shard::metadata()['suite_time'] ?? null;
+
+        if (is_numeric($reference) && (float) $reference > $measured) {
+            return (float) $reference;
+        }
+
+        return $measured;
     }
 
     /**

--- a/src/Tester/MutationTestRunner.php
+++ b/src/Tester/MutationTestRunner.php
@@ -130,8 +130,7 @@ class MutationTestRunner implements MutationTestRunnerContract
             }
         }
 
-        $coveredLines = array_map(fn (array $lines): array => array_filter($lines, fn (?array $tests): bool => $tests !== [] && $tests !== null), $coverageData->lineCoverage());
-        $coveredLines = array_filter($coveredLines, fn (array $lines): bool => $lines !== []);
+        $coveredLines = $this->coveredLines($coverageData);
 
         $files = FileFinder::files($this->getConfiguration()->paths, $this->getConfiguration()->pathsToIgnore);
 
@@ -190,6 +189,62 @@ class MutationTestRunner implements MutationTestRunnerContract
         Facade::instance()->emitter()->finishMutationSuite($mutationSuite);
 
         return $this->isMinScoreIsReached($mutationSuite) ? 0 : 1;
+    }
+
+    /**
+     * Returns the tests covering each line, as `[file => [line => [testId, ...]]]`.
+     *
+     * @return array<string, array<int, array<int, string>>>
+     */
+    private function coveredLines(ProcessedCodeCoverageData $coverageData): array
+    {
+        /** @var array<int, string> $testIds */
+        $testIds = method_exists($coverageData, 'testIds') ? $coverageData->testIds() : []; // @phpstan-ignore function.alreadyNarrowedType
+
+        $coveredLines = [];
+
+        foreach ($coverageData->lineCoverage() as $file => $lines) {
+            foreach ($lines as $line => $tests) {
+                $ids = $this->testIdsCoveringLine($tests ?? [], $testIds);
+
+                if ($ids === []) {
+                    continue;
+                }
+
+                $coveredLines[$file][$line] = $ids;
+            }
+        }
+
+        return $coveredLines;
+    }
+
+    /**
+     * Resolves the test ids a single line holds.
+     *
+     * Up to phpunit/php-code-coverage 14.2 a line held the test ids themselves. Since
+     * 14.3 it holds hit counts, keyed by an index into the coverage data's test ids.
+     *
+     * @param  array<int|string, mixed>  $tests
+     * @param  array<int, string>  $testIds
+     * @return array<int, string>
+     */
+    private function testIdsCoveringLine(array $tests, array $testIds): array
+    {
+        $ids = [];
+
+        foreach ($tests as $index => $test) {
+            if (is_string($test)) {
+                $ids[] = $test;
+
+                continue;
+            }
+
+            if (is_int($index) && isset($testIds[$index])) {
+                $ids[] = $testIds[$index];
+            }
+        }
+
+        return $ids;
     }
 
     private function getConfiguration(): Configuration

--- a/tests/Unit/MutationTestTest.php
+++ b/tests/Unit/MutationTestTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Pest\Mutate\Mutation;
+use Pest\Mutate\MutationTest;
+use Symfony\Component\Finder\SplFileInfo;
+
+it('reads the fully qualified test class out of a coverage identifier', function (string $identifier, string $expected): void {
+    $test = new MutationTest(new Mutation(new SplFileInfo(__FILE__, '', ''), 'id', 'SomeMutator', 1, 2, '', ''));
+
+    $method = new ReflectionClass($test)->getMethod('testClass');
+
+    expect($method->invoke($test, $identifier))->toBe($expected);
+})->with([
+    'pest test' => ['P\Tests\Unit\FooTest::__pest_evaluable_it_works', 'Tests\Unit\FooTest'],
+    'phpunit test' => ['Tests\Unit\FooTest::test_bar', 'Tests\Unit\FooTest'],
+    'dataset' => ['P\Tests\Unit\FooTest::__pest_evaluable_it_works#0', 'Tests\Unit\FooTest'],
+    'unnamespaced' => ['P\FooTest::test_bar', 'FooTest'],
+    'no separator' => ['Tests\Unit\FooTest', 'Tests\Unit\FooTest'],
+]);
+
+it('has no covering test classes before it starts', function (): void {
+    $test = new MutationTest(new Mutation(new SplFileInfo(__FILE__, '', ''), 'id', 'SomeMutator', 1, 2, '', ''));
+
+    expect($test->coveringTestClasses())->toBe([]);
+});

--- a/tests/Unit/Repositories/MutationRepositoryTest.php
+++ b/tests/Unit/Repositories/MutationRepositoryTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+use Pest\Mutate\Mutation;
+use Pest\Mutate\MutationTest;
+use Pest\Mutate\Repositories\MutationRepository;
+use Symfony\Component\Finder\SplFileInfo;
+
+/**
+ * @param  array<int, string>  $coveringTestClasses
+ */
+$addMutation = function (MutationRepository $repository, string $id, float $duration, array $coveringTestClasses): void {
+    $file = new SplFileInfo(__FILE__, '', '');
+
+    $repository->add(new Mutation($file, $id, 'SomeMutator', 1, 2, '', ''));
+
+    $tests = $repository->all()[$file->getRealPath()]->tests();
+    $test = end($tests);
+
+    assert($test instanceof MutationTest);
+
+    $reflection = new ReflectionClass($test);
+    $reflection->getProperty('start')->setValue($test, 0.0);
+    $reflection->getProperty('finish')->setValue($test, $duration);
+    $reflection->getProperty('coveringTestClasses')->setValue($test, $coveringTestClasses);
+};
+
+describe('units', function () use ($addMutation): void {
+    it('groups the mutations of a file into one unit, with every test covering it', function () use ($addMutation): void {
+        $repository = new MutationRepository;
+
+        $addMutation($repository, 'a', 2.0, ['Tests\\Unit\\FooTest', 'Tests\\Unit\\BarTest']);
+        $addMutation($repository, 'b', 0.5, ['Tests\\Unit\\FooTest']);
+
+        expect($repository->units(dirname(__DIR__, 3)))->toBe([
+            'tests/Unit/Repositories/MutationRepositoryTest.php' => [
+                'time' => 2.5,
+                'tests' => ['Tests\\Unit\\FooTest', 'Tests\\Unit\\BarTest'],
+            ],
+        ]);
+    });
+
+    it('leaves out a file no test covers', function () use ($addMutation): void {
+        $repository = new MutationRepository;
+
+        $addMutation($repository, 'a', 0.0, []);
+
+        expect($repository->units(dirname(__DIR__, 3)))->toBe([]);
+    });
+
+    it('keeps an absolute path when the file is outside the root', function () use ($addMutation): void {
+        $repository = new MutationRepository;
+
+        $addMutation($repository, 'a', 1.0, ['Tests\\Unit\\FooTest']);
+
+        expect(array_keys($repository->units('/somewhere/else')))->toBe([__FILE__]);
+    });
+
+    it('returns nothing when no mutation ran', function (): void {
+        expect(new MutationRepository()->units('/'))->toBe([]);
+    });
+});

--- a/tests/Unit/Tester/MutationTestRunnerTest.php
+++ b/tests/Unit/Tester/MutationTestRunnerTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Pest\Mutate\Tester\MutationTestRunner;
+
+/**
+ * @param  array<int|string, mixed>  $tests
+ * @param  array<int, string>  $testIds
+ * @param  array<int, string>  $expected
+ */
+it('resolves the tests covering a line from either code coverage shape', function (array $tests, array $testIds, array $expected): void {
+    $runner = new MutationTestRunner;
+
+    $method = new ReflectionClass($runner)->getMethod('testIdsCoveringLine');
+
+    expect($method->invoke($runner, $tests, $testIds))->toBe($expected);
+})->with([
+    'ids in the values, up to php-code-coverage 14.2' => [
+        ['P\Tests\Unit\FooTest::__pest_evaluable_it_works', 'Tests\Unit\BarTest::test_baz'],
+        [],
+        ['P\Tests\Unit\FooTest::__pest_evaluable_it_works', 'Tests\Unit\BarTest::test_baz'],
+    ],
+    'hit counts keyed by index, since php-code-coverage 14.3' => [
+        [0 => 1, 2 => 4],
+        [
+            0 => 'P\Tests\Unit\FooTest::__pest_evaluable_it_works',
+            1 => 'Tests\Unit\OtherTest::test_untouched',
+            2 => 'Tests\Unit\BarTest::test_baz',
+        ],
+        ['P\Tests\Unit\FooTest::__pest_evaluable_it_works', 'Tests\Unit\BarTest::test_baz'],
+    ],
+    'an index with no test id is dropped' => [[7 => 1], [0 => 'Tests\Unit\FooTest::test_baz'], []],
+    'nothing covers the line' => [[], [], []],
+]);


### PR DESCRIPTION
The timeout given to each mutation is derived from the duration of the initial test run. A shard runs only part of the suite, so its initial run is shorter and the window shrinks, while the work a single mutation does is unchanged: the subprocess still pays the framework bootstrap plus the tests covering that mutation. Mutations killed on a full run get cut off as timeouts instead, and since a timeout counts as a killed mutation the score stays high while the run gets slower and the result less honest.

## What changed

`--update-shards` cannot be combined with `--shard`, so the run that writes the timings file is always unsharded and can serve as the reference. It records the duration of its initial test run as metadata next to the units, and a sharded run takes whichever is longer, its own measurement or that reference. An unsharded run behaves exactly as before.

The window is deliberately still derived from the suite rather than from the tests covering each individual mutation. The narrower model is more accurate, but it would shorten the window wherever the covering tests are fast, which risks introducing timeouts in suites that pass today.

## Result

Measured on 4 shards: 8 timeouts instead of 18, critical path 105s instead of 135s, total work across the shards 364s instead of 483s.

Adding up the shards gives `tested=661 untested=2 timeout=8 total=671 score=99.70%` against `tested=664 untested=2 timeout=5 total=671 score=99.70%` for an unsharded run of the same code. Total, escaped and score match exactly; the remaining difference between 8 and 5 timeouts sits inside the run-to-run variance of the machine.

## Depends on

Requires `Shard::metadata()` added in pestphp/pest#1829.

This branch also carries the commits from #39 and #40, which should be merged first; once they are, this diff reduces to the timeout change alone.
