### PR TITLE
fix: handle mutation child errors and processes option

### DIFF
--- a/src/Contracts/Printer.php
+++ b/src/Contracts/Printer.php
@@ -20,6 +20,8 @@ interface Printer
 
     public function reportTimedOutMutation(MutationTest $test): void;
 
+    public function reportErroredMutation(MutationTest $test): void;
+
     public function reportError(string $message): void;
 
     public function reportScoreNotReached(float $scoreReached, float $scoreRequired): void;

--- a/src/Event/Emitter.php
+++ b/src/Event/Emitter.php
@@ -6,6 +6,8 @@ namespace Pest\Mutate\Event;
 
 use Pest\Mutate\Event\Events\Test\HookMethod\BeforeFirstTestExecuted;
 use Pest\Mutate\Event\Events\Test\HookMethod\BeforeFirstTestExecutedSubscriber;
+use Pest\Mutate\Event\Events\Test\Outcome\Errored;
+use Pest\Mutate\Event\Events\Test\Outcome\ErroredSubscriber;
 use Pest\Mutate\Event\Events\Test\Outcome\Tested;
 use Pest\Mutate\Event\Events\Test\Outcome\TestedSubscriber;
 use Pest\Mutate\Event\Events\Test\Outcome\Timeout;
@@ -65,6 +67,16 @@ class Emitter
 
         foreach (Facade::instance()->subscribers()[TimeoutSubscriber::class] ?? [] as $subscriber) {
             /** @var TimeoutSubscriber $subscriber */
+            $subscriber->notify($event);
+        }
+    }
+
+    public function mutationErrored(MutationTest $test): void
+    {
+        $event = new Errored($test);
+
+        foreach (Facade::instance()->subscribers()[ErroredSubscriber::class] ?? [] as $subscriber) {
+            /** @var ErroredSubscriber $subscriber */
             $subscriber->notify($event);
         }
     }

--- a/src/Event/Events/Test/Outcome/Errored.php
+++ b/src/Event/Events/Test/Outcome/Errored.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Mutate\Event\Events\Test\Outcome;
+
+use Pest\Mutate\Contracts\Event;
+use Pest\Mutate\MutationTest;
+
+class Errored implements Event
+{
+    public function __construct(
+        public MutationTest $test,
+    ) {}
+}

--- a/src/Event/Events/Test/Outcome/ErroredSubscriber.php
+++ b/src/Event/Events/Test/Outcome/ErroredSubscriber.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Mutate\Event\Events\Test\Outcome;
+
+use Pest\Mutate\Contracts\Subscriber;
+
+interface ErroredSubscriber extends Subscriber
+{
+    public function notify(Errored $event): void;
+}

--- a/src/MutationTest.php
+++ b/src/MutationTest.php
@@ -145,11 +145,21 @@ class MutationTest
             return true;
         }
 
+        if ($this->process->getExitCode() !== 1) {
+            $this->updateResult(MutationTestResult::Errored);
+
+            Facade::instance()->emitter()->mutationErrored($this);
+
+            $this->finish = microtime(true);
+
+            return true;
+        }
+
         $this->updateResult(MutationTestResult::Tested);
 
-        Facade::instance()->emitter()->mutationTested($this);
-
         $this->finish = microtime(true);
+
+        Facade::instance()->emitter()->mutationTested($this);
 
         return true;
     }

--- a/src/MutationTestCollection.php
+++ b/src/MutationTestCollection.php
@@ -51,6 +51,11 @@ class MutationTestCollection
         return count(array_filter($this->tests, fn (MutationTest $test): bool => $test->result() === MutationTestResult::Timeout));
     }
 
+    public function errored(): int
+    {
+        return count(array_filter($this->tests, fn (MutationTest $test): bool => $test->result() === MutationTestResult::Errored));
+    }
+
     public function uncovered(): int
     {
         return count(array_filter($this->tests, fn (MutationTest $test): bool => $test->result() === MutationTestResult::Uncovered));

--- a/src/Options/ProcessesOption.php
+++ b/src/Options/ProcessesOption.php
@@ -12,7 +12,7 @@ class ProcessesOption
 
     public static function remove(): bool
     {
-        return false;
+        return true;
     }
 
     public static function match(string $argument): bool

--- a/src/Plugins/Mutate.php
+++ b/src/Plugins/Mutate.php
@@ -17,6 +17,8 @@ use Pest\Mutate\Contracts\MutationTestRunner;
 use Pest\Mutate\Contracts\Printer;
 use Pest\Mutate\Event\Events\Test\HookMethod\BeforeFirstTestExecuted;
 use Pest\Mutate\Event\Events\Test\HookMethod\BeforeFirstTestExecutedSubscriber;
+use Pest\Mutate\Event\Events\Test\Outcome\Errored;
+use Pest\Mutate\Event\Events\Test\Outcome\ErroredSubscriber;
 use Pest\Mutate\Event\Events\Test\Outcome\Tested;
 use Pest\Mutate\Event\Events\Test\Outcome\TestedSubscriber;
 use Pest\Mutate\Event\Events\Test\Outcome\Timeout;
@@ -230,6 +232,14 @@ class Mutate implements AddsOutput, Bootable, HandlesArguments
                 public function notify(Timeout $event): void
                 {
                     $this->printer()->reportTimedOutMutation($event->test);
+                }
+            },
+
+            new class($printer) extends PrinterSubscriber implements ErroredSubscriber
+            {
+                public function notify(Errored $event): void
+                {
+                    $this->printer()->reportErroredMutation($event->test);
                 }
             },
 

--- a/src/Repositories/MutationRepository.php
+++ b/src/Repositories/MutationRepository.php
@@ -61,6 +61,11 @@ class MutationRepository
         return array_sum(array_map(fn (MutationTestCollection $testCollection): int => $testCollection->timedOut(), $this->tests));
     }
 
+    public function errored(): int
+    {
+        return array_sum(array_map(fn (MutationTestCollection $testCollection): int => $testCollection->errored(), $this->tests));
+    }
+
     public function uncovered(): int
     {
         return array_sum(array_map(fn (MutationTestCollection $testCollection): int => $testCollection->uncovered(), $this->tests));

--- a/src/Support/MutationTestResult.php
+++ b/src/Support/MutationTestResult.php
@@ -11,4 +11,5 @@ enum MutationTestResult: string
     case Uncovered = 'uncovered';
     case Untested = 'untested';
     case Timeout = 'timeout';
+    case Errored = 'errored';
 }

--- a/src/Support/Printers/DefaultPrinter.php
+++ b/src/Support/Printers/DefaultPrinter.php
@@ -71,6 +71,17 @@ class DefaultPrinter implements Printer
         $this->writeMutationTestLine('yellow', 't', $test);
     }
 
+    public function reportErroredMutation(MutationTest $test): void
+    {
+        if ($this->compact) {
+            $this->output->write('<fg=red;options=bold>e</>');
+
+            return;
+        }
+
+        $this->writeMutationTestLine('red', 'e', $test);
+    }
+
     public function printFilename(MutationTestCollection $testCollection): void
     {
         if ($this->compact) {
@@ -132,7 +143,7 @@ class DefaultPrinter implements Printer
         $this->writeMutationSuiteSummary($mutationSuite);
 
         $this->output->writeln([
-            '  <fg=gray>Mutations:</> <fg=default>'.($mutationSuite->repository->untested() !== 0 ? '<fg=red;options=bold>'.$mutationSuite->repository->untested().' untested</><fg=gray>,</> ' : '').($mutationSuite->repository->uncovered() !== 0 ? '<fg=yellow;options=bold>'.$mutationSuite->repository->uncovered().' uncovered</><fg=gray>,</> ' : '').($mutationSuite->repository->notRun() !== 0 ? '<fg=yellow;options=bold>'.$mutationSuite->repository->notRun().' pending</><fg=gray>,</> ' : '').($mutationSuite->repository->timedOut() !== 0 ? '<fg=green;options=bold>'.$mutationSuite->repository->timedOut().' timeout</><fg=gray>,</> ' : '').'<fg=green;options=bold>'.$mutationSuite->repository->tested().' tested</>',
+            '  <fg=gray>Mutations:</> <fg=default>'.($mutationSuite->repository->untested() !== 0 ? '<fg=red;options=bold>'.$mutationSuite->repository->untested().' untested</><fg=gray>,</> ' : '').($mutationSuite->repository->errored() !== 0 ? '<fg=red;options=bold>'.$mutationSuite->repository->errored().' errored</><fg=gray>,</> ' : '').($mutationSuite->repository->uncovered() !== 0 ? '<fg=yellow;options=bold>'.$mutationSuite->repository->uncovered().' uncovered</><fg=gray>,</> ' : '').($mutationSuite->repository->notRun() !== 0 ? '<fg=yellow;options=bold>'.$mutationSuite->repository->notRun().' pending</><fg=gray>,</> ' : '').($mutationSuite->repository->timedOut() !== 0 ? '<fg=green;options=bold>'.$mutationSuite->repository->timedOut().' timeout</><fg=gray>,</> ' : '').'<fg=green;options=bold>'.$mutationSuite->repository->tested().' tested</>',
         ]);
 
         $score = number_format($mutationSuite->score(), 2);
@@ -179,7 +190,7 @@ class DefaultPrinter implements Printer
 
     private function writeMutationTestSummary(MutationTest $test): void
     {
-        if (! in_array($test->result(), [MutationTestResult::Untested, MutationTestResult::Uncovered], true)) {
+        if (! in_array($test->result(), [MutationTestResult::Untested, MutationTestResult::Uncovered, MutationTestResult::Errored], true)) {
             return;
         }
 
@@ -195,6 +206,9 @@ class DefaultPrinter implements Printer
         if ($test->result() === MutationTestResult::Untested) {
             $color = 'red';
             $label = 'UNTESTED';
+        } elseif ($test->result() === MutationTestResult::Errored) {
+            $color = 'red';
+            $label = 'ERRORED';
         } else {
             $color = 'bright-red';
             $label = 'UNCOVERED';

--- a/tests/Unit/MutationTestTest.php
+++ b/tests/Unit/MutationTestTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+use Pest\Mutate\Mutation;
+use Pest\Mutate\MutationTest;
+use Pest\Mutate\Repositories\TelemetryRepository;
+use Pest\Mutate\Support\Configuration\Configuration;
+use Pest\Mutate\Support\MutationTestResult;
+use Pest\Support\Container;
+use Symfony\Component\Finder\SplFileInfo;
+
+it('does not report an errored mutation child process as tested', function (): void {
+    $sourcePath = tempnam(sys_get_temp_dir(), 'pest-mutate-source-');
+    $modifiedSourcePath = tempnam(sys_get_temp_dir(), 'pest-mutate-modified-');
+
+    expect($sourcePath)->toBeString()
+        ->and($modifiedSourcePath)->toBeString();
+
+    file_put_contents($sourcePath, "<?php\nreturn true;\n");
+    file_put_contents($modifiedSourcePath, "<?php\nreturn false;\n");
+
+    $telemetryRepository = new TelemetryRepository;
+    $telemetryRepository->initialTestSuiteDuration(0.1);
+    Container::getInstance()->add(TelemetryRepository::class, $telemetryRepository);
+
+    $mutation = new Mutation(
+        file: new SplFileInfo($sourcePath, '', ''),
+        id: 'errored-mutation',
+        mutator: 'FakeMutator',
+        startLine: 2,
+        endLine: 2,
+        diff: '',
+        modifiedSourcePath: $modifiedSourcePath,
+    );
+
+    $mutationTest = new MutationTest($mutation);
+
+    $started = $mutationTest->start(
+        coveredLines: [
+            $mutation->file->getRealPath() => [
+                2 => ['Tests\\Unit\\MutationTestTest::it fails inside the child process'],
+            ],
+        ],
+        configuration: new Configuration(
+            coveredOnly: false,
+            paths: [],
+            pathsToIgnore: [],
+            mutators: [],
+            classes: [],
+            parallel: false,
+            processes: 1,
+            profile: false,
+            minScore: null,
+            ignoreMinScoreOnZeroMutations: false,
+            stopOnUntested: false,
+            stopOnUncovered: false,
+            mutationId: null,
+            retry: false,
+            everything: false,
+        ),
+        originalArguments: [
+            'php',
+            '-r',
+            'fwrite(STDERR, "child error"); exit(2);',
+            '--',
+        ],
+    );
+
+    expect($started)->toBeTrue();
+
+    while (! $mutationTest->hasFinished()) {
+        usleep(1_000);
+    }
+
+    expect($mutationTest->result())->not->toBe(MutationTestResult::Tested);
+});

--- a/tests/Unit/Options/ProcessesOptionTest.php
+++ b/tests/Unit/Options/ProcessesOptionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Pest\Mutate\Support\Configuration\CliConfiguration;
+
+it('removes the processes option from forwarded test-run arguments when parallel is enabled', function (): void {
+    $configuration = new CliConfiguration;
+
+    $arguments = $configuration->fromArguments([
+        'vendor/bin/pest',
+        'tests',
+        '--mutate',
+        '--parallel',
+        '--processes=2',
+    ]);
+
+    expect($configuration->toArray())
+        ->parallel->toBeTrue()
+        ->processes->toBe(2);
+
+    expect($arguments)
+        ->toContain('vendor/bin/pest')
+        ->toContain('tests')
+        ->not->toContain('--mutate')
+        ->not->toContain('--parallel')
+        ->not->toContain('--processes=2');
+});


### PR DESCRIPTION
This PR proposes a small fix for two related behaviours around mutation parallel execution. I am opening it to confirm whether these behaviours are intentional, but both currently seem to make mutation results less reliable.

`--parallel` is removed from the initial test run so mutation testing can collect coverage before running mutations itself. `--processes`, however, is still forwarded to that initial run. When `--parallel` is removed but `--processes` remains, the initial run can fail before mutation testing starts.

Mutation child processes also treat every non-successful exit as a tested mutation. That makes assertion failures and runtime errors indistinguishable, so a child process error can be counted as a killed mutation and inflate the score.

## What changed
`ProcessesOption` is now removed from the forwarded initial test-run arguments after being read into the mutation configuration.
Mutation child processes now distinguish assertion failures from execution errors. Exit code `1` is still reported as `tested`, while other non-successful exits are reported as `errored`.
The new `errored` result is wired through the result enum, counters, events, and printer output.

## Testing

- `composer test`