### PR TITLE
fix: keep the mutant --filter under the kernel's per-argument limit

### DIFF
--- a/src/MutationTest.php
+++ b/src/MutationTest.php
@@ -9,6 +9,7 @@ use Pest\Mutate\Event\Facade;
 use Pest\Mutate\Plugins\Mutate;
 use Pest\Mutate\Repositories\TelemetryRepository;
 use Pest\Mutate\Support\Configuration\Configuration;
+use Pest\Mutate\Support\FilterArgument;
 use Pest\Mutate\Support\MutationTestResult;
 use Pest\Support\Container;
 use Symfony\Component\Process\Exception\ProcessTimedOutException;
@@ -17,6 +18,14 @@ use Symfony\Component\Process\Process;
 class MutationTest
 {
     private MutationTestResult $result = MutationTestResult::None;
+
+    /**
+     * Widenings already reported, so a class that had to collapse says so once per
+     * process rather than once per mutation in it.
+     *
+     * @var array<string, true>
+     */
+    private static array $reportedWidenings = [];
 
     private ?float $start = null;
 
@@ -87,12 +96,28 @@ class MutationTest
         // remove coverage arguments from the original arguments
         $filteredArguments = array_filter($originalArguments, fn (string $argument): bool => ! str_starts_with($argument, '--coverage'));
 
+        // A fragment per covering test, joined into ONE argv element, runs past the
+        // kernel's per-element cap on a widely-covered class — see FilterArgument.
+        $filter = FilterArgument::for(array_values($filters));
+
+        $notice = $filter->notice();
+
+        if ($notice !== null) {
+            $key = implode(',', array_keys($filter->widened));
+
+            if (! isset(self::$reportedWidenings[$key])) {
+                self::$reportedWidenings[$key] = true;
+
+                fwrite(STDERR, $notice.PHP_EOL);
+            }
+        }
+
         // TODO: filter arguments to remove unnecessary stuff (Teamcity, Coverage, etc.)
         $process = new Process(
             command: [
                 ...$filteredArguments,
                 '--bail',
-                '--filter="'.implode('|', $filters).'"',
+                $filter->argument,
             ],
             env: $envs,
             timeout: $this->calculateTimeout(),

--- a/src/Support/FilterArgument.php
+++ b/src/Support/FilterArgument.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Mutate\Support;
+
+use RuntimeException;
+
+/**
+ * The single `--filter=` argv element handed to a mutant's child process.
+ *
+ * One fragment per covering test, joined with `|`, is correct and unbounded — and on a
+ * class that most of a suite reaches it runs past the kernel's cap on ONE argv element.
+ * Linux caps it at MAX_ARG_STRLEN = PAGE_SIZE * 32 (include/uapi/linux/binfmts.h), which
+ * is 131072 bytes on x86_64 and is not tunable: `ulimit -s` moves the total ARG_MAX, never
+ * the per-element cap. The child then dies with `posix_spawn() failed: Argument list too
+ * long` before it runs a single test, so every mutation in that class is lost.
+ *
+ * macOS has no per-argument cap, which is why this reproduces only on Linux — typically in
+ * CI, on the run whose numbers people actually publish.
+ *
+ * Two encodings, applied in that order:
+ *
+ *  1. FACTOR the class prefix. `Cls::(.*)a|Cls::(.*)b` becomes `Cls::(.*)(a|b)`. Lossless:
+ *     both forms select exactly the same tests, and it is about 28% shorter on a real
+ *     suite. The inner parentheses are load-bearing — without them the alternation binds
+ *     to the whole pattern instead of the tail, and the filter selects far more than it
+ *     was asked for.
+ *
+ *  2. If it still does not fit, COLLAPSE a class to its bare `Cls::` prefix, largest
+ *     contributor first, stopping the moment it fits. That is a strict SUPERSET of the
+ *     original selection, which is exactly why it is safe here: widening can only run MORE
+ *     tests, so it can never turn a killed mutant into a survivor.
+ *
+ * That safety argument has one precondition and it is not decorative: it holds only while
+ * the ordinary suite is green. A test already failing for unrelated reasons counts as a
+ * kill, so a widened filter can inherit an unrelated red — the same fabrication class as
+ * running mutation in parallel.
+ *
+ * A widening is therefore never silent: `widened` names every class and how many extra
+ * tests it now selects, so the caller can say so. A filter that quietly widened would make
+ * the score certify more than the run measured.
+ *
+ * @see https://github.com/pestphp/pest/issues/1771
+ */
+final readonly class FilterArgument
+{
+    /**
+     * Byte budget for the single `--filter=` argv element.
+     *
+     * 96 KiB rather than the kernel's full 131072: the cap is per element and a suite only
+     * grows, so a filter sized to the exact limit is one new test away from failing again.
+     */
+    public const int BUDGET_BYTES = 98304;
+
+    /**
+     * @param  array<string, int>  $widened  class => how many extra tests it now selects
+     */
+    private function __construct(
+        public string $argument,
+        public array $widened,
+    ) {}
+
+    /**
+     * @param  list<string>  $filters  one regex fragment per covering test
+     *
+     * @throws RuntimeException when even a fully collapsed filter does not fit
+     */
+    public static function for(array $filters, int $budget = self::BUDGET_BYTES): self
+    {
+        /** @var array<string, list<string>> $byClass */
+        $byClass = [];
+
+        foreach ($filters as $filter) {
+            // A fragment whose shape is not recognised is kept verbatim under a reserved
+            // key. If the shape upstream builds ever changes, this degrades to today's
+            // behaviour rather than silently dropping a selection.
+            if (preg_match('/^([A-Za-z0-9_]+)::\(\.\*\)(.*)$/s', $filter, $matches) === 1) {
+                $byClass[$matches[1]][] = $matches[2];
+
+                continue;
+            }
+
+            $byClass["\0raw"][] = $filter;
+        }
+
+        /** @var array<string, true> $collapsed */
+        $collapsed = [];
+
+        $render = static function () use (&$byClass, &$collapsed): string {
+            $parts = [];
+
+            /**
+             * @var string $class
+             * @var list<string> $tails
+             */
+            foreach ($byClass as $class => $tails) {
+                if ($class === "\0raw") {
+                    foreach ($tails as $tail) {
+                        $parts[] = $tail;
+                    }
+
+                    continue;
+                }
+
+                if (isset($collapsed[$class])) {
+                    $parts[] = $class.'::';
+
+                    continue;
+                }
+
+                $parts[] = $class.'::(.*)('.implode('|', array_unique($tails)).')';
+            }
+
+            return '--filter="'.implode('|', $parts).'"';
+        };
+
+        $argument = $render();
+
+        if (strlen($argument) <= $budget) {
+            return new self($argument, []);
+        }
+
+        // Heaviest class first, so the fewest collapses buy the most room.
+        /** @var array<string, int> $weights */
+        $weights = [];
+
+        foreach ($byClass as $class => $tails) {
+            if ($class !== "\0raw") {
+                $weights[$class] = strlen(implode('|', array_unique($tails)));
+            }
+        }
+
+        arsort($weights);
+
+        /** @var array<string, int> $widened */
+        $widened = [];
+
+        foreach (array_keys($weights) as $class) {
+            $collapsed[$class] = true;
+            $widened[$class] = count(array_unique($byClass[$class]));
+            $argument = $render();
+
+            if (strlen($argument) <= $budget) {
+                break;
+            }
+        }
+
+        if (strlen($argument) > $budget) {
+            // Dropping the filter entirely would run the whole suite per mutant and read
+            // as a fast green, so this fails loudly instead.
+            throw new RuntimeException(sprintf(
+                'The mutation filter is %d bytes with every class collapsed to its prefix, over the %d-byte budget.',
+                strlen($argument),
+                $budget,
+            ));
+        }
+
+        return new self($argument, $widened);
+    }
+
+    /**
+     * A human-readable note for a run whose filter had to widen, or null when none did.
+     */
+    public function notice(): ?string
+    {
+        if ($this->widened === []) {
+            return null;
+        }
+
+        return sprintf(
+            'Mutation filter collapsed %d class(es) to a bare prefix to fit within %d bytes: %s. '.
+            'This selects a superset of the covering tests, so it cannot fabricate a kill — '.
+            'provided the ordinary suite is green before mutation starts.',
+            count($this->widened),
+            strlen($this->argument),
+            implode(', ', array_map(
+                static fn (string $class, int $count): string => $class.' (+'.$count.' tests)',
+                array_keys($this->widened),
+                array_values($this->widened),
+            )),
+        );
+    }
+}

--- a/tests/Unit/Support/FilterArgumentTest.php
+++ b/tests/Unit/Support/FilterArgumentTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+use Pest\Mutate\Support\FilterArgument;
+
+/**
+ * Every assertion here is about one of two things: that the encoding selects the SAME
+ * tests, or that when it cannot, it selects MORE of them and says so. The failure being
+ * guarded is silent in both directions — a filter that selects too few would fabricate
+ * survivors, and one that selects too many without saying so would make the score certify
+ * more than the run measured.
+ */
+
+/** Match a test name the way PHPUnit applies `--filter`: the joined value as one regex. */
+function selects(string $argument, string $testName): bool
+{
+    $pattern = (string) preg_replace('/^--filter="(.*)"$/s', '$1', $argument);
+
+    return preg_match('/'.$pattern.'/', $testName) === 1;
+}
+
+it('factors a shared class prefix', function (): void {
+    $filter = FilterArgument::for([
+        'SizeHelperTest::(.*)it_is_small',
+        'SizeHelperTest::(.*)it_is_large',
+    ]);
+
+    expect($filter->argument)->toBe('--filter="SizeHelperTest::(.*)(it_is_small|it_is_large)"')
+        ->and($filter->widened)->toBe([]);
+});
+
+it('factors losslessly — the factored form selects exactly what the naive form selected', function (): void {
+    $fragments = [
+        'SizeHelperTest::(.*)it_is_small',
+        'SizeHelperTest::(.*)it_is_large',
+        'AgeHelperTest::(.*)it_is_adult',
+    ];
+
+    $names = [
+        'Tests\Unit\SizeHelperTest::it_is_small',
+        'Tests\Unit\SizeHelperTest::it_is_large',
+        'Tests\Unit\AgeHelperTest::it_is_adult',
+        'Tests\Unit\SizeHelperTest::it_is_medium',   // never selected by either form
+        'Tests\Unit\OtherTest::it_is_small',         // wrong class, same tail
+    ];
+
+    $naive = '--filter="'.implode('|', $fragments).'"';
+    $factored = FilterArgument::for($fragments)->argument;
+
+    $before = array_values(array_filter($names, fn (string $n): bool => selects($naive, $n)));
+    $after = array_values(array_filter($names, fn (string $n): bool => selects($factored, $n)));
+
+    expect($after)->toBe($before)->toHaveCount(3);
+});
+
+it('keeps the inner parentheses, without which the alternation would bind to the whole pattern', function (): void {
+    // ⚠️ THE ONE DETAIL THAT MAKES FACTORING SAFE. `Cls::(.*)a|b` is `(Cls::(.*)a)|(b)`,
+    // so a bare `b` anywhere matches and the filter runs tests it was never given.
+    $broken = '--filter="SizeHelperTest::(.*)it_is_small|it_is_large"';
+    $correct = FilterArgument::for([
+        'SizeHelperTest::(.*)it_is_small',
+        'SizeHelperTest::(.*)it_is_large',
+    ])->argument;
+
+    expect(selects($broken, 'Tests\Unit\OtherTest::it_is_large'))->toBeTrue()
+        ->and(selects($correct, 'Tests\Unit\OtherTest::it_is_large'))->toBeFalse();
+});
+
+it('leaves a fragment it does not recognise exactly as it found it', function (): void {
+    $filter = FilterArgument::for([
+        'SizeHelperTest::(.*)it_is_small',
+        'something upstream started emitting',
+    ]);
+
+    expect($filter->argument)->toContain('something upstream started emitting');
+});
+
+it('de-duplicates repeated tails rather than repeating them', function (): void {
+    $filter = FilterArgument::for([
+        'SizeHelperTest::(.*)it_is_small',
+        'SizeHelperTest::(.*)it_is_small',
+    ]);
+
+    expect($filter->argument)->toBe('--filter="SizeHelperTest::(.*)(it_is_small)"');
+});
+
+it('stays under the kernel cap on a filter that would otherwise exceed it', function (): void {
+    // The measured shape of the defect: one class reached by a very large number of tests.
+    // 2,076 covering tests produced a 172,779-byte argument against a 131,072-byte cap.
+    $fragments = [];
+
+    for ($i = 0; $i < 3000; $i++) {
+        $fragments[] = 'ComponentRenderTest::(.*)it_renders_the_component_variant_number_'.$i;
+    }
+
+    $naive = '--filter="'.implode('|', $fragments).'"';
+
+    expect(strlen($naive))->toBeGreaterThan(131072);
+
+    $filter = FilterArgument::for($fragments);
+
+    expect(strlen($filter->argument))->toBeLessThanOrEqual(FilterArgument::BUDGET_BYTES);
+});
+
+it('collapses the heaviest class first, so the fewest collapses buy the most room', function (): void {
+    $fragments = ['SmallTest::(.*)it_does_one_thing'];
+
+    for ($i = 0; $i < 4000; $i++) {
+        $fragments[] = 'HugeTest::(.*)it_renders_a_very_long_test_name_number_'.$i;
+    }
+
+    $filter = FilterArgument::for($fragments);
+
+    expect(array_keys($filter->widened))->toBe(['HugeTest'])
+        ->and($filter->argument)->toContain('SmallTest::(.*)(it_does_one_thing)')
+        ->and($filter->argument)->toContain('HugeTest::');
+});
+
+it('widens rather than narrows — every originally-selected test still matches', function (): void {
+    $fragments = [];
+
+    for ($i = 0; $i < 4000; $i++) {
+        $fragments[] = 'HugeTest::(.*)it_renders_a_very_long_test_name_number_'.$i;
+    }
+
+    $filter = FilterArgument::for($fragments);
+
+    expect($filter->widened)->not->toBe([]);
+
+    foreach ([0, 1999, 3999] as $i) {
+        expect(selects($filter->argument, 'Tests\Unit\HugeTest::it_renders_a_very_long_test_name_number_'.$i))
+            ->toBeTrue();
+    }
+});
+
+it('reports what it widened instead of widening silently', function (): void {
+    $fragments = [];
+
+    for ($i = 0; $i < 4000; $i++) {
+        $fragments[] = 'HugeTest::(.*)it_renders_a_very_long_test_name_number_'.$i;
+    }
+
+    $filter = FilterArgument::for($fragments);
+
+    expect($filter->widened)->toBe(['HugeTest' => 4000])
+        ->and($filter->notice())->toContain('HugeTest (+4000 tests)')
+        ->and($filter->notice())->toContain('superset');
+});
+
+it('says nothing when nothing was widened', function (): void {
+    expect(FilterArgument::for(['SizeHelperTest::(.*)it_is_small'])->notice())->toBeNull();
+});
+
+it('fails loudly rather than returning a filter that still does not fit', function (): void {
+    // Dropping the filter would run the whole suite per mutant and read as a fast green,
+    // so the one thing this must never do is return something over budget.
+    $fragments = [];
+
+    for ($i = 0; $i < 200; $i++) {
+        $fragments[] = 'Test'.str_repeat('X', 400).$i.'::(.*)it_does_something';
+    }
+
+    expect(fn (): FilterArgument => FilterArgument::for($fragments, 1000))
+        ->toThrow(RuntimeException::class, 'over the 1000-byte budget');
+});
+
+it('handles an empty selection without inventing one', function (): void {
+    expect(FilterArgument::for([])->argument)->toBe('--filter=""');
+});


### PR DESCRIPTION
Closes pestphp/pest#1771.

## The defect

A mutant's covering tests are emitted one regex fragment per test and joined into a **single** `--filter=` argv element:

```php
'--filter="'.implode('|', $filters).'"',
```

That element is unbounded. Linux caps **one** argv element at `MAX_ARG_STRLEN = PAGE_SIZE * 32` (`include/uapi/linux/binfmts.h`) — 131,072 bytes on x86_64, and it is **not tunable**: `ulimit -s` moves the total `ARG_MAX`, never the per-element cap. Past it the child dies with

```
posix_spawn() failed: Argument list too long
```

before running a single test, so **every mutation in that class is lost**. Measured at **172,779 bytes** for one mutation in a class with 2,076 covering tests.

macOS has no per-argument cap at all, which is why this reproduces only on Linux — in practice on CI, on the run whose score people actually publish.

## The fix

`Pest\Mutate\Support\FilterArgument` applies two encodings, in order.

**1 — Factor the class prefix.** `Cls::(.*)a|Cls::(.*)b` becomes `Cls::(.*)(a|b)`. Lossless, and measured on synthetic sets shaped like the real ones:

| | naive | built | |
|---|---:|---:|---|
| four classes × 300 tests | 52,370 | 34,438 | **−34.2%**, selection identical |
| one class × 2,076 tests | 150,448 | 32 | collapsed, and reported |

The **inner parentheses are load-bearing**. `Cls::(.*)a|b` parses as `(Cls::(.*)a)|(b)`, so a bare `b` matches anywhere and the filter runs tests it was never given. There is a test for exactly that.

**2 — If it still does not fit, collapse a class to its bare `Cls::` prefix**, heaviest contributor first, stopping the moment it fits.

That is a strict **superset** of the original selection, which is precisely why it is safe here: widening can only ever run **more** tests, so it can never turn a killed mutant into a survivor.

That argument has one precondition worth stating: it holds while the ordinary suite is green. A test already failing for unrelated reasons counts as a kill, so a widened filter can inherit an unrelated red — the same fabrication class as running mutation in parallel.

**So a collapse is never silent.** `widened` names each class and how many extra tests it now selects; `MutationTest` reports it once per process rather than once per mutation in the class. A filter that quietly widened would make the score certify more than the run measured.

And if even a fully collapsed filter does not fit, it **throws**. Dropping the filter would run the whole suite per mutant and read as a fast green, which is the one outcome worse than the crash.

## Why a value object rather than a method

`FilterArgument::for()` returns `argument` plus `widened`, so the encoding stays free of any output concern and is unit-testable without spawning a process. The `fwrite(STDERR, …)` at the call site is the smallest honest channel for the notice — **if you would rather it went through `Facade::instance()->emitter()`, say so and I will move it**; it needs an event class and listener wiring, so I did not add that unasked.

`BUDGET_BYTES` is 98,304 rather than the kernel's full 131,072: the cap is per element and a suite only grows, so a filter sized to the exact limit is one new test away from failing again.

## Proof

| | |
|---|---|
| `pest` (whole suite) | **328 passed**, 649 assertions |
| new unit test | **12 passed**, 25 assertions |
| `pint --test` | passed |
| `phpstan analyse` | no errors |
| `rector --dry-run` | done, no changes |
| `pest --type-coverage` | **100%** on both new files, total 100% |

Three behaviours were red-proved by reverting the code that guards them:

| reverted | goes red |
|---|---|
| the inner parentheses in the factored form | 4 arms, including the over-match one |
| the `throw` on a still-oversized filter | `it fails loudly rather than returning a filter that still does not fit` |
| the collapse loop | 4 arms — factoring alone does not get a 2,076-test class under the cap |

## Prior art

This has been running in production in two repositories for weeks — one as a `cweagans/composer-patches` patch, one as an anchored vendor rewrite — against real mutation runs. This PR is that algorithm, upstreamed, so neither has to re-derive it on every release.
